### PR TITLE
MR: Update buildpack value to make gateway work in cf

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,6 @@ applications:
     instances: 1
     stack: cflinuxfs2
     path: .
-    command: bash ./ec.sh
-    buildpacks: ["https://github.com/cloudfoundry/binary-buildpack.git"]
+    command: bash ./gateway.sh
+    buildpack: https://github.com/cloudfoundry/binary-buildpack.git#v1.0.32
+


### PR DESCRIPTION
The latest buildpack of cloud foundry is not compatible with EC service so need to specify the version of builpack which is compatible with EC.